### PR TITLE
Separate trace and metric agent port

### DIFF
--- a/pkg/constant/env.go
+++ b/pkg/constant/env.go
@@ -1,11 +1,15 @@
 package constant
 
 const (
-	EnvKeyOtelEnabled         = "OTEL_ENABLED"
-	EnvKeyOtelCollectorUrl    = "OTEL_COLLECTOR_URL"
-	EnvKeyOtelInsecure        = "OTEL_INSECURE"
-	EnvKeyOtelProtocol        = "OTEL_PROTOCOL"
-	EnvKeyOtelServiceName     = "OTEL_SERVICE_NAME"
-	EnvKeyOtelServiceVersion  = "OTEL_SERVICE_VERSION"
-	EnvKeyOtelTraceSampleRate = "OTEL_TRACE_SAMPLE_RATE"
+	EnvKeyOtelEnabled             = "OTEL_ENABLED"
+	EnvKeyOtelAgentHost           = "OTEL_AGENT_HOST"
+	EnvKeyOtelMetricAgentGRPCPort = "OTEL_METRIC_AGENT_GRPC_PORT"
+	EnvKeyOtelMetricAgentHTTPPort = "OTEL_METRIC_AGENT_HTTP_PORT"
+	EnvKeyOtelTraceAgentGRPCPort  = "OTEL_TRACE_AGENT_GRPC_PORT"
+	EnvKeyOtelTraceAgentHTTPPort  = "OTEL_TRACE_AGENT_HTTP_PORT"
+	EnvKeyOtelInsecure            = "OTEL_INSECURE"
+	EnvKeyOtelProtocol            = "OTEL_PROTOCOL"
+	EnvKeyOtelServiceName         = "OTEL_SERVICE_NAME"
+	EnvKeyOtelServiceVersion      = "OTEL_SERVICE_VERSION"
+	EnvKeyOtelTraceSampleRate     = "OTEL_TRACE_SAMPLE_RATE"
 )

--- a/pkg/constant/otlp.go
+++ b/pkg/constant/otlp.go
@@ -1,9 +1,13 @@
 package constant
 
 const (
-	OtelDefaultServiceName    = "default-service-name"
-	OtelDefaultServiceVersion = "0.1.0"
-	OtelProtocolGRPC          = "grpc"
-	OtelProtocolHTTP          = "http"
-	OtelDefaultSampleRate     = 0.5
+	OtelDefaultServiceName         = "default-service-name"
+	OtelDefaultServiceVersion      = "0.1.0"
+	OtelProtocolGRPC               = "grpc"
+	OtelProtocolHTTP               = "http"
+	OtelDefaultTraceAgentGRPCPort  = "4317"
+	OtelDefaultTraceAgentHTTPPort  = "4318"
+	OtelDefaultMetricAgentGRPCPort = "4315"
+	OtelDefaultMetricAgentHTTPPort = "4316"
+	OtelDefaultSampleRate          = 0.5
 )

--- a/pkg/metric/provider.go
+++ b/pkg/metric/provider.go
@@ -23,7 +23,8 @@ var provider *metric.MeterProvider
 var lock sync.Mutex
 
 func newGRPCExporter(ctx context.Context, agentHost string, isInsecure bool) (metric.Exporter, error) {
-	addr := net.JoinHostPort(agentHost, env.StringFromEnv(constant.EnvKeyOtelMetricAgentGRPCPort, "4315"))
+	addr := net.JoinHostPort(agentHost, env.StringFromEnv(
+		constant.EnvKeyOtelMetricAgentGRPCPort, constant.OtelDefaultMetricAgentGRPCPort))
 	clientOpts := []otlpmetricgrpc.Option{
 		otlpmetricgrpc.WithEndpoint(addr),
 		otlpmetricgrpc.WithDialOption(grpc.WithBlock()),
@@ -39,7 +40,8 @@ func newGRPCExporter(ctx context.Context, agentHost string, isInsecure bool) (me
 }
 
 func newHTTPExporter(ctx context.Context, agentHost string, isInsecure bool) (metric.Exporter, error) {
-	addr := net.JoinHostPort(agentHost, env.StringFromEnv(constant.EnvKeyOtelMetricAgentHTTPPort, "4316"))
+	addr := net.JoinHostPort(agentHost, env.StringFromEnv(
+		constant.EnvKeyOtelMetricAgentHTTPPort, constant.OtelDefaultMetricAgentHTTPPort))
 	clientOpts := []otlpmetrichttp.Option{
 		otlpmetrichttp.WithEndpoint(addr),
 	}

--- a/pkg/metric/provider.go
+++ b/pkg/metric/provider.go
@@ -3,6 +3,7 @@ package metric
 import (
 	"context"
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -21,9 +22,10 @@ import (
 var provider *metric.MeterProvider
 var lock sync.Mutex
 
-func newGRPCExporter(ctx context.Context, providerServerUrl string, isInsecure bool) (metric.Exporter, error) {
+func newGRPCExporter(ctx context.Context, agentHost string, isInsecure bool) (metric.Exporter, error) {
+	addr := net.JoinHostPort(agentHost, env.StringFromEnv(constant.EnvKeyOtelMetricAgentGRPCPort, "4315"))
 	clientOpts := []otlpmetricgrpc.Option{
-		otlpmetricgrpc.WithEndpoint(providerServerUrl),
+		otlpmetricgrpc.WithEndpoint(addr),
 		otlpmetricgrpc.WithDialOption(grpc.WithBlock()),
 	}
 	if isInsecure {
@@ -36,9 +38,10 @@ func newGRPCExporter(ctx context.Context, providerServerUrl string, isInsecure b
 	return exporter, nil
 }
 
-func newHTTPExporter(ctx context.Context, providerServerUrl string, isInsecure bool) (metric.Exporter, error) {
+func newHTTPExporter(ctx context.Context, agentHost string, isInsecure bool) (metric.Exporter, error) {
+	addr := net.JoinHostPort(agentHost, env.StringFromEnv(constant.EnvKeyOtelMetricAgentHTTPPort, "4316"))
 	clientOpts := []otlpmetrichttp.Option{
-		otlpmetrichttp.WithEndpoint(providerServerUrl),
+		otlpmetrichttp.WithEndpoint(addr),
 	}
 	if isInsecure {
 		clientOpts = append(clientOpts, otlpmetrichttp.WithInsecure())
@@ -54,17 +57,17 @@ func newOTLPExporter() (metric.Exporter, error) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
-	providerServerUrl := env.StringFromEnv(constant.EnvKeyOtelCollectorUrl, "")
+	agentHost := env.StringFromEnv(constant.EnvKeyOtelAgentHost, "")
 	isInsecure := env.BoolFromEnv(constant.EnvKeyOtelInsecure)
 	protocol := env.StringFromEnv(constant.EnvKeyOtelProtocol, constant.OtelProtocolGRPC)
 
 	// gRPC
 	if protocol == constant.OtelProtocolGRPC {
-		return newGRPCExporter(ctx, providerServerUrl, isInsecure)
+		return newGRPCExporter(ctx, agentHost, isInsecure)
 	}
 
 	// HTTP
-	return newHTTPExporter(ctx, providerServerUrl, isInsecure)
+	return newHTTPExporter(ctx, agentHost, isInsecure)
 }
 
 func newResources() *resource.Resource {

--- a/pkg/tracer/provider.go
+++ b/pkg/tracer/provider.go
@@ -25,7 +25,8 @@ var provider *trace.TracerProvider
 var lock sync.Mutex
 
 func newGRPCExporter(ctx context.Context, agentHost string, isInsecure bool) (*otlptrace.Exporter, error) {
-	addr := net.JoinHostPort(agentHost, env.StringFromEnv(constant.EnvKeyOtelTraceAgentGRPCPort, "4317"))
+	addr := net.JoinHostPort(agentHost, env.StringFromEnv(
+		constant.EnvKeyOtelTraceAgentGRPCPort, constant.OtelDefaultTraceAgentGRPCPort))
 	clientOpts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(addr),
 		otlptracegrpc.WithDialOption(grpc.WithBlock()),
@@ -43,7 +44,8 @@ func newGRPCExporter(ctx context.Context, agentHost string, isInsecure bool) (*o
 }
 
 func newHTTPExporter(ctx context.Context, agentHost string, isInsecure bool) (*otlptrace.Exporter, error) {
-	addr := net.JoinHostPort(agentHost, env.StringFromEnv(constant.EnvKeyOtelTraceAgentHTTPPort, "4318"))
+	addr := net.JoinHostPort(agentHost, env.StringFromEnv(
+		constant.EnvKeyOtelTraceAgentHTTPPort, constant.OtelDefaultTraceAgentHTTPPort))
 	clientOpts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpoint(addr),
 	}


### PR DESCRIPTION
Separate trace and metric agent port to overcome bugs that related to stucked metrics
- Trace agent port: 4317 for grpc and 4318 for http
- Metric agent port: 4315 for grpc and 4316 for http